### PR TITLE
Add unified agent platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ The repository will evolve as more features and integrations are added. Check ba
 
 Contributions are welcome. Feel free to open issues or pull requests with improvements, new integrations, or references to emerging research.
 
+
+## Unified Agent Platform
+
+The `unified_platform` package provides a single interface for managing agents across Azure, Bedrock, and GCP SDKs. It exposes helper classes for creating agents, threads, functions, telemetry, and agent connections. Stub clients demonstrate the expected API for each provider.

--- a/tests/test_unified_sdk.py
+++ b/tests/test_unified_sdk.py
@@ -1,0 +1,28 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from unified_platform.unified_sdk import UnifiedAgentPlatform
+from unified_platform.stubs import AzureStubClient, BedrockStubClient, GCPStubClient
+
+
+def test_basic_workflow():
+    azure = AzureStubClient()
+    bedrock = BedrockStubClient()
+    gcp = GCPStubClient()
+
+    platform = UnifiedAgentPlatform(azure_client=azure, bedrock_client=bedrock, gcp_client=gcp)
+
+    azure_agent = platform.create_agent("azure-agent", provider="azure")
+    bedrock_agent = platform.create_agent("bedrock-agent", provider="bedrock")
+    gcp_agent = platform.create_agent("gcp-agent", provider="gcp")
+
+    thread = platform.create_thread(azure_agent, provider="azure")
+    assert thread in azure.threads
+
+    platform.add_function(azure_agent, {"name": "echo"}, provider="azure")
+    assert {"name": "echo"} in azure.agents[azure_agent]["functions"]
+
+    platform.enable_telemetry(azure_agent, {"level": "basic"}, provider="azure")
+    assert azure.agents[azure_agent]["telemetry"] == {"level": "basic"}
+
+    platform.connect_agent(azure_agent, bedrock_agent, provider="azure")
+    assert bedrock_agent in azure.agents[azure_agent].get("connections", [])
+

--- a/unified_platform/stubs.py
+++ b/unified_platform/stubs.py
@@ -1,0 +1,37 @@
+class BaseStubClient:
+    def __init__(self):
+        self.agents = {}
+        self.threads = {}
+
+    def create_agent(self, name, **kwargs):
+        agent_id = f"agent-{len(self.agents)+1}"
+        self.agents[agent_id] = {'name': name, 'functions': [], 'telemetry': None}
+        return agent_id
+
+    def create_thread(self, agent_id, **kwargs):
+        thread_id = f"thread-{len(self.threads)+1}"
+        self.threads[thread_id] = {'agent_id': agent_id, 'messages': []}
+        return thread_id
+
+    def add_function(self, agent_id, func_spec, **kwargs):
+        self.agents[agent_id]['functions'].append(func_spec)
+        return True
+
+    def enable_telemetry(self, agent_id, telemetry_config, **kwargs):
+        self.agents[agent_id]['telemetry'] = telemetry_config
+        return True
+
+    def connect_agent(self, agent_id, other_agent_id, **kwargs):
+        connection = self.agents[agent_id].setdefault('connections', [])
+        connection.append(other_agent_id)
+        return True
+
+class AzureStubClient(BaseStubClient):
+    pass
+
+class BedrockStubClient(BaseStubClient):
+    pass
+
+class GCPStubClient(BaseStubClient):
+    pass
+

--- a/unified_platform/unified_sdk.py
+++ b/unified_platform/unified_sdk.py
@@ -1,0 +1,57 @@
+class UnifiedAgentPlatform:
+    """Unified interface for Azure, Bedrock, and GCP agent SDKs."""
+
+    def __init__(self, azure_client=None, bedrock_client=None, gcp_client=None):
+        self.azure_client = azure_client
+        self.bedrock_client = bedrock_client
+        self.gcp_client = gcp_client
+
+    def _get_client(self, provider):
+        if provider == 'azure':
+            return self.azure_client
+        if provider == 'bedrock':
+            return self.bedrock_client
+        if provider == 'gcp':
+            return self.gcp_client
+        raise ValueError(f"Unsupported provider: {provider}")
+
+    def create_agent(self, name, provider='azure', **kwargs):
+        client = self._get_client(provider)
+        if not client:
+            raise RuntimeError(f"{provider} client not configured")
+        if hasattr(client, 'create_agent'):
+            return client.create_agent(name, **kwargs)
+        raise NotImplementedError(f"create_agent not implemented for {provider}")
+
+    def create_thread(self, agent_id, provider='azure', **kwargs):
+        client = self._get_client(provider)
+        if not client:
+            raise RuntimeError(f"{provider} client not configured")
+        if hasattr(client, 'create_thread'):
+            return client.create_thread(agent_id, **kwargs)
+        raise NotImplementedError(f"create_thread not implemented for {provider}")
+
+    def add_function(self, agent_id, func_spec, provider='azure', **kwargs):
+        client = self._get_client(provider)
+        if not client:
+            raise RuntimeError(f"{provider} client not configured")
+        if hasattr(client, 'add_function'):
+            return client.add_function(agent_id, func_spec, **kwargs)
+        raise NotImplementedError(f"add_function not implemented for {provider}")
+
+    def enable_telemetry(self, agent_id, telemetry_config, provider='azure', **kwargs):
+        client = self._get_client(provider)
+        if not client:
+            raise RuntimeError(f"{provider} client not configured")
+        if hasattr(client, 'enable_telemetry'):
+            return client.enable_telemetry(agent_id, telemetry_config, **kwargs)
+        raise NotImplementedError(f"enable_telemetry not implemented for {provider}")
+
+    def connect_agent(self, agent_id, other_agent_id, provider='azure', **kwargs):
+        client = self._get_client(provider)
+        if not client:
+            raise RuntimeError(f"{provider} client not configured")
+        if hasattr(client, 'connect_agent'):
+            return client.connect_agent(agent_id, other_agent_id, **kwargs)
+        raise NotImplementedError(f"connect_agent not implemented for {provider}")
+


### PR DESCRIPTION
## Summary
- build `unified_platform` package with a unified API for Azure, Bedrock, and GCP agent SDKs
- add stub clients that simulate provider behavior
- include pytest test demonstrating the workflow
- document the new module in README
- add `.gitignore` for build artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d84c5e3483299e6538e502d7b927